### PR TITLE
alignment "の"

### DIFF
--- a/src/concepts/workloads/controllers/daemonset.md
+++ b/src/concepts/workloads/controllers/daemonset.md
@@ -3,7 +3,7 @@ DaemonSet
 
 # What is a DaemonSet?
 
-*DaemonSet*はすべて(またはいくつかの)NodeでPodのコピーを実行することを保証します。
+*DaemonSet*はすべて(またはいくつか)のNodeでPodのコピーを実行することを保証します。
 NodeがClusterに追加されると、Podはそれらに追加されます。
 NodeがClusterから削除されると、PodはGarbage Collectionされます。
 DaemonSetを削除すると作成されたPodも削除されます。


### PR DESCRIPTION
DaemonSetの説明について、カッコ書き内に接続詞の "の" があって、カッコ内を排して読んだ場合に接続詞がなく文章として読めませんでした。